### PR TITLE
Add build step to CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+      - master
   pull_request:
   workflow_dispatch:
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -45,6 +45,9 @@ jobs:
       - name: Install extra dependencies
         run: julia --project -e 'using Books; Books.install_dependencies()'
 
+      - name: Build the book
+        run: julia --project -e 'using ResearchBook; ResearchBook.build()'
+
       - name: Deploy to secondary branch
         # Always updates documentation when ubuntu passes, which is fine.
         if: ${{ ( github.event_name == 'push' || github.event_name == 'workflow_dispatch') && runner.os == 'Linux' }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,2 +1,14 @@
+name = "ResearchBook"
+uuid = "253a2a1b-8823-4248-9e95-df7dc46fd77a"
+authors = ["Jacob Zelko"]
+version = "0.1.0"
+
 [deps]
 Books = "939d5c6b-51ae-42e7-97ca-7564d0d4ad91"
+DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
+Reexport = "189a3867-3050-52da-a836-e630ba90ab69"
+
+[compat]
+Books = "0.7"
+DataFrames = "1"
+Reexport = "1"

--- a/metadata.yml
+++ b/metadata.yml
@@ -31,7 +31,8 @@ code-block-font-size: \scriptsize
 
 titlepage: true
 linkReferences: true
-bibliography: /home/src/Knowledgebase/Zettelkasten/zettel.bib 
+# This is not gonna work in CI.
+# bibliography: /home/src/Knowledgebase/Zettelkasten/zettel.bib
 link-citations: true
 
 # These table of contents settings only affect the PDF.

--- a/src/ResearchBook.jl
+++ b/src/ResearchBook.jl
@@ -1,0 +1,19 @@
+module ResearchBook
+
+using Reexport
+@reexport using Books
+@reexport using DataFrames
+
+"""
+    build()
+
+This function is called during CI.
+"""
+function build()
+    println("Building ResearchBook")
+    # Fail on error to avoid broken websites.
+    Books.gen(; fail_on_error=true)
+    Books.build_all()
+end
+
+end # module


### PR DESCRIPTION
I've also set the compat entries because this makes the book more reproducible and allows you to use CompatHelper later. That way it's reasonably easy to maintain the book